### PR TITLE
Move typescript + linting tools to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,13 +9,22 @@
     "Lisi Linhart <ewl@storyblok.com"
   ],
   "devDependencies": {
+    "@commitlint/cli": "^17.5.0",
+    "@commitlint/config-conventional": "^17.4.4",
+    "@tsconfig/recommended": "^1.0.2",
+    "@typescript-eslint/eslint-plugin": "^5.56.0",
+    "@typescript-eslint/parser": "^5.56.0",
     "eslint": "^8.36.0",
+    "eslint-config-prettier": "^8.8.0",
     "eslint-plugin-import": "^2.27.5",
     "eslint-plugin-jest": "^27.2.1",
     "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-promise": "^6.1.1",
+    "husky": "^8.0.3",
     "jest": "^29.5.0",
-    "microbundle": "^0.15.1"
+    "microbundle": "^0.15.1",
+    "prettier": "^2.8.6",
+    "typescript": "^5.0.2"
   },
   "source": "src/index.ts",
   "main": "dist/index.umd.js",
@@ -31,17 +40,8 @@
     "prepare": "npm run-script build"
   },
   "dependencies": {
-    "@commitlint/cli": "^17.5.0",
-    "@commitlint/config-conventional": "^17.4.4",
     "@tiptap/pm": "^2.0.0-beta.220",
-    "@tsconfig/recommended": "^1.0.2",
-    "@typescript-eslint/eslint-plugin": "^5.56.0",
-    "@typescript-eslint/parser": "^5.56.0",
-    "eslint-config-prettier": "^8.8.0",
-    "husky": "^8.0.3",
-    "markdown-it": "^13.0.1",
-    "prettier": "^2.8.6",
-    "typescript": "^5.0.2"
+    "markdown-it": "^13.0.1"
   },
   "release": {
     "branches": [


### PR DESCRIPTION
Hello 👋 Ran into a little problem with some of the dependencies for this package that I think should be devDependencies instead.

>**Move typescript + linting tools to devDependencies**
>Consumers of this package should not need to have the same versions of typescript, eslint, prettier etc as this package uses internally at build time.

For me the dependencies of `"@typescript-eslint/eslint-plugin": "^5.56.0"`, `"@typescript-eslint/parser": "^5.56.0"`, prevented me from upgrading to `@typescript-eslint/eslint-parser@6.3.0` in my project.
